### PR TITLE
Enable home access

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -18,6 +18,8 @@ apps:
       LANG: C.UTF-8
     plugs:
       - network
+      - home
+      - removable-media
 
 parts:
   toot:


### PR DESCRIPTION
Add home and removable media interfaces so users can easily upload photos/pictures from home and removable media.