### PR TITLE
Enable launching browser

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -20,6 +20,7 @@ apps:
       - network
       - home
       - removable-media
+      - desktop
 
 parts:
   toot:


### PR DESCRIPTION
When doing a "toot login" it is unable to launch the browser. Snappy debug suggests using the desktop interface to enable this.

```= AppArmor =
Time: Oct 27 17:02:17
Log: apparmor="DENIED" operation="exec" profile="snap.toot.toot" name="/usr/bin/xdg-open" pid=20441 comm="python3" requested_mask="x" denied_mask="x" fsuid=1000 ouid=0
File: /usr/bin/xdg-open (exec)
Suggestion:
* add one of 'desktop, unity7' to 'plugs'
```